### PR TITLE
Require guild membership to register a passport

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,7 +73,7 @@ export default async function Home({
               <SignInButton dark />
             </div>
           ) : null}
-          {session?.user?.email && !guildMember ? (
+          {session?.user?.email && (guildMember === undefined) ? (
             <div className="rounded-sm border-[3px] border-red-400 flex flex-col justify-center w-full md:w-10/12 gap-4 p-3 sm:p-4 my-4 mx-auto break-inside-avoid shadow-red-600 shadow-blocks-sm font-main">
               <p>
                 Please join the Purdue Hackers Discord server before signing in!

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@/auth";
-import { SignInButton } from "@/components/auth-buttons";
+import { SignInButton, JoinGuildButton } from "@/components/auth-buttons";
 import Playground from "@/components/playground";
 import UserInfo from "@/components/user-info";
 import { getOptimizedLatestPassportImage } from "@/lib/get-optimized-latest-passport-image";
@@ -20,6 +20,7 @@ export default async function Home({
   let session = (await auth()) as MySession | null;
   const userId = session?.token?.sub;
   const latestPassport = session?.passport;
+  const guildMember = session?.guildMember; 
 
   let optimizedLatestPassportImage: OptimizedLatestPassportImage | null = null;
   if (latestPassport) {
@@ -72,11 +73,21 @@ export default async function Home({
               <SignInButton dark />
             </div>
           ) : null}
+          {session?.user?.email && !guildMember ? (
+            <div className="rounded-sm border-[3px] border-red-400 flex flex-col justify-center w-full md:w-10/12 gap-4 p-3 sm:p-4 my-4 mx-auto break-inside-avoid shadow-red-600 shadow-blocks-sm font-main">
+              <p>
+                Please join the Purdue Hackers Discord server before signing in!
+                After joining, please refresh this page.
+              </p>
+              <JoinGuildButton dark />
+            </div>
+          ) : null}
         </div>
         <Playground
           userId={userId}
           latestPassport={latestPassport}
           optimizedLatestPassportImage={optimizedLatestPassportImage}
+          guildMember={guildMember}
         />
       </div>
     </main>

--- a/auth.ts
+++ b/auth.ts
@@ -29,17 +29,21 @@ export const authConfig = {
       const bigIntUserId = BigInt(`${token.sub}`);
       let guildMember;
 
-      const guilds = await fetch("https://discordapp.com/api/users/@me/guilds", {
-        headers: {
-          Authorization: "Bearer " + token.accessToken,
-          "Content-Type": "application/json"
-        }
-      })
-        .then(function (guilds) {
-          return guilds.json()
-        }).then(async function (data) {
-          guildMember = data.find((o: { id: string; }) => o.id === process.env.DISCORD_GUILD ?? "");
+      if (process.env.DISCORD_GUILD) {
+        const guilds = await fetch("https://discordapp.com/api/users/@me/guilds", {
+          headers: {
+            Authorization: "Bearer " + token.accessToken,
+            "Content-Type": "application/json"
+          }
         })
+          .then(function (guilds) {
+            return guilds.json()
+          }).then(async function (data) {
+            guildMember = data.find((o: { id: string; }) => o.id === process.env.DISCORD_GUILD ?? "");
+          })
+      } else {
+        guildMember = null;
+      }
 
       let user = await prisma.user.findFirst({
         where: {

--- a/auth.ts
+++ b/auth.ts
@@ -36,9 +36,9 @@ export const authConfig = {
             "Content-Type": "application/json"
           }
         })
-          .then(function (guilds) {
+          .then( (guilds) => {
             return guilds.json()
-          }).then(async function (data) {
+          }).then(async (data) => {
             guildMember = data.find((o: { id: string; }) => o.id === process.env.DISCORD_GUILD ?? "");
           })
       } else {

--- a/auth.ts
+++ b/auth.ts
@@ -10,7 +10,7 @@ export const authConfig = {
       clientSecret: process.env.DISCORD_CLIENT_SECRET ?? "",
       token: "https://discord.com/api/oauth2/token",
       userinfo: "https://discord.com/api/users/@me",
-      authorization: "https://discord.com/api/oauth2/authorize?scope=identify+email+guilds",
+      authorization: "https://discord.com/api/oauth2/authorize?scope=identify+guilds",
     }),
   ],
   session: {

--- a/components/auth-buttons.tsx
+++ b/components/auth-buttons.tsx
@@ -1,5 +1,6 @@
 import { signIn, signOut } from "@/auth";
 import { Button } from "./ui/button";
+import Link from 'next/link';
 
 export function SignOutButton() {
   return (
@@ -44,5 +45,28 @@ export function SignInButton({ dark }: { dark?: boolean }) {
         Sign in with Discord
       </Button>
     </form>
+  );
+}
+
+export function JoinGuildButton({ dark }: { dark?: boolean }) {
+  return (
+    <Link
+      href={`https://puhack.horse/discord`}
+      className={`mx-auto shadow-blocks-tiny shadow-discord-deselected border-2 border-black ${
+        dark ? "" : "bg-discord-light hover:bg-discord-vibrant"
+      }`}
+    >
+      <Button
+        className={`${
+          dark
+            ? "bg-discord-vibrant hover:bg-discord-light hover:text-black"
+            : "bg-discord-light hover:bg-discord-vibrant"
+        } shadow-none border-none rounded-none h-6`}
+        variant="auth"
+        type="submit"
+      >
+        Join the Server!
+      </Button>
+    </Link>
   );
 }

--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -77,10 +77,12 @@ export default function Playground({
   userId,
   latestPassport,
   optimizedLatestPassportImage,
+  guildMember,
 }: {
   userId: string | undefined;
   latestPassport: Passport | null | undefined;
   optimizedLatestPassportImage: OptimizedLatestPassportImage | null;
+  guildMember: object | undefined;
 }) {
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
@@ -304,7 +306,7 @@ export default function Playground({
               </FormItem>
             )}
           />
-          {userId ? (
+          {userId && guildMember ? (
             <FormField
               control={form.control}
               name="sendToDb"

--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -82,7 +82,7 @@ export default function Playground({
   userId: string | undefined;
   latestPassport: Passport | null | undefined;
   optimizedLatestPassportImage: OptimizedLatestPassportImage | null;
-  guildMember: object | undefined;
+  guildMember: object | null | undefined;
 }) {
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
@@ -306,7 +306,7 @@ export default function Playground({
               </FormItem>
             )}
           />
-          {userId && guildMember ? (
+          {userId && (guildMember !== undefined) ? (
             <FormField
               control={form.control}
               name="sendToDb"

--- a/types/types.ts
+++ b/types/types.ts
@@ -6,7 +6,7 @@ export interface MySession {
   expires: string;
   token: Token;
   passport: Passport | null;
-  guildMember: object | undefined;
+  guildMember: object | null | undefined;
 }
 
 export interface Token {

--- a/types/types.ts
+++ b/types/types.ts
@@ -6,6 +6,7 @@ export interface MySession {
   expires: string;
   token: Token;
   passport: Passport | null;
+  guildMember: object | undefined;
 }
 
 export interface Token {


### PR DESCRIPTION
This adds a check to make sure a given Discord account is a member of a guild when creating a passport. If they are not a member, they will be prompted with an invite link (Currently hard coded to `https://puhack.horse/discord`). On the next refresh, their membership will be noticed.

Notable Changes:
- A new .env variable is introduced: `DISCORD_GUILD` - This should be the Guild ID of the membership guild. For deployment, this will be `772576325897945119`.
- New type guildMember: This new type is passed around to verify membership in the guild, I couldn't think of a better name at time of writing

See the following demo video:

https://github.com/user-attachments/assets/a9f7ea17-9251-47bc-bd98-fcd667c17060

Edit: Closes #12 