### PR TITLE
Change /activated to redirect on No Session or No Passport

### DIFF
--- a/app/activated/page.tsx
+++ b/app/activated/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from "@/auth";
 import UserInfo from "@/components/user-info";
 import { MySession } from "@/types/types";
-import { notFound } from "next/navigation";
+import { redirect } from "next/navigation";
 import Image from "next/image";
 import { ImageActions } from "@/components/image-actions";
 import Link from "next/link";
@@ -18,7 +18,7 @@ export default async function Activated() {
   const latestPassport = session?.passport;
 
   if (!latestPassport) {
-    notFound();
+    redirect("/");
   }
 
   const { latestPassportImageUrl, base64, metadata } =


### PR DESCRIPTION
Closes #37 

Changes the /activated endpoint to redirect to "/" rather then returning the less friendly 404 Not Found page.