### PR TITLE
Add confetti to passport generation

### DIFF
--- a/app/activated/page.tsx
+++ b/app/activated/page.tsx
@@ -45,7 +45,7 @@ export default async function Activated() {
             </p>
           </div>
           <div className="w-full md:w-8/12 mx-auto flex flex-col items-center gap-2">
-          <Image
+            <Image
               alt={`Passport for discord id ${latestPassport.id}`}
               src={latestPassportImageUrl}
               width={metadata.width / 2}

--- a/app/activated/page.tsx
+++ b/app/activated/page.tsx
@@ -7,6 +7,7 @@ import { ImageActions } from "@/components/image-actions";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { getOptimizedLatestPassportImage } from "@/lib/get-optimized-latest-passport-image";
+import LaunchConfetti from "@/lib/confetti";
 
 export default async function Activated() {
   // Although the session includes the JWT token type from `auth.ts`, when it gets here
@@ -44,7 +45,7 @@ export default async function Activated() {
             </p>
           </div>
           <div className="w-full md:w-8/12 mx-auto flex flex-col items-center gap-2">
-            <Image
+          <Image
               alt={`Passport for discord id ${latestPassport.id}`}
               src={latestPassportImageUrl}
               width={metadata.width / 2}
@@ -81,6 +82,7 @@ export default async function Activated() {
           </Link>
         </div>
       </div>
+      <LaunchConfetti />
     </main>
   );
 }

--- a/components/image-actions.tsx
+++ b/components/image-actions.tsx
@@ -5,7 +5,6 @@ import { Button } from "./ui/button";
 import { useEffect, useState } from "react";
 import LaunchConfetti from "@/lib/confetti";
 
-
 export function ImageActions({
   generatedImageUrl,
   userId,

--- a/components/image-actions.tsx
+++ b/components/image-actions.tsx
@@ -3,6 +3,8 @@
 import { Passport } from "@/types/types";
 import { Button } from "./ui/button";
 import { useEffect, useState } from "react";
+import LaunchConfetti from "@/lib/confetti";
+
 
 export function ImageActions({
   generatedImageUrl,
@@ -47,6 +49,7 @@ export function ImageActions({
         <Button className="w-full amberButton" type="button">
           Download
         </Button>
+        <LaunchConfetti />
       </a>
       {userId && (latestPassport || sendToDb) ? (
         <div>

--- a/lib/confetti.tsx
+++ b/lib/confetti.tsx
@@ -31,8 +31,6 @@ function LaunchConfetti() {
       instance.current({
         ...commonOptions
       });
-    } else {
-      console.warn('Confetti function is not initialized');
     }
   };
 

--- a/lib/confetti.tsx
+++ b/lib/confetti.tsx
@@ -22,16 +22,22 @@ const commonOptions = {
 };
 
 function LaunchConfetti() {
-  const instance = useRef();
+  const instance = useRef<((options: any) => void) | undefined>(undefined);
 
-  const onInit = ({ confetti }) => {
+  const onInit = ({ confetti }: { confetti: (options: any) => void }) => {
     instance.current = confetti;
   };
 
   const fire = () => {
-    instance.current({
-          ...commonOptions
-    });
+    // Ensure instance.current is defined and callable
+    if (instance.current) {
+      instance.current({
+        // Assuming commonOptions is defined elsewhere in your code
+        ...commonOptions
+      });
+    } else {
+      console.warn('Confetti function is not initialized');
+    }
   };
 
   useEffect(() => {

--- a/lib/confetti.tsx
+++ b/lib/confetti.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import React, { useRef, useEffect } from "react";
-//import { createRoot } from "react-dom";
 import ReactCanvasConfetti from "react-canvas-confetti";
 
 const commonOptions = {
@@ -10,7 +9,6 @@ const commonOptions = {
   gravity: 1,
   decay: 0.9,
   startVelocity: 85,
-  //colors: ["FFE400", "FFBD00", "E89400", "FFCA6C", "FDFFB8"],
   colors: ["FCD34D", "FFFFFF"],
   particleCount: 300,
   shapes: ["square", "circle"],
@@ -29,10 +27,8 @@ function LaunchConfetti() {
   };
 
   const fire = () => {
-    // Ensure instance.current is defined and callable
     if (instance.current) {
       instance.current({
-        // Assuming commonOptions is defined elsewhere in your code
         ...commonOptions
       });
     } else {

--- a/lib/confetti.tsx
+++ b/lib/confetti.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import React, { useRef, useEffect } from "react";
+//import { createRoot } from "react-dom";
+import ReactCanvasConfetti from "react-canvas-confetti";
+
+const commonOptions = {
+  spread: 180,
+  ticks: 240,
+  gravity: 1,
+  decay: 0.9,
+  startVelocity: 85,
+  //colors: ["FFE400", "FFBD00", "E89400", "FFCA6C", "FDFFB8"],
+  colors: ["FCD34D", "FFFFFF"],
+  particleCount: 300,
+  shapes: ["square", "circle"],
+  angle: 90,
+  origin: {
+    x: .5,
+    y: 1.25,
+  },
+};
+
+function LaunchConfetti() {
+  const instance = useRef();
+
+  const onInit = ({ confetti }) => {
+    instance.current = confetti;
+  };
+
+  const fire = () => {
+    instance.current({
+          ...commonOptions
+    });
+  };
+
+  useEffect(() => {
+    fire();
+  }, []);
+
+  return (
+    <>
+      <ReactCanvasConfetti onInit={onInit} />
+    </>
+  );
+}
+
+export default LaunchConfetti;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "next-auth": "5.0.0-beta.5",
     "plaiceholder": "^3.0.0",
     "react": "^18",
+    "react-canvas-confetti": "^2.0.7",
     "react-dom": "^18",
     "react-hook-form": "^7.49.3",
     "react-image-crop": "^11.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,9 @@ importers:
       react:
         specifier: ^18
         version: 18.2.0
-      react-canvas-confetti: 
+      react-canvas-confetti:
         specifier: ^2.0.7
-        version: 2.0.7
+        version: 2.0.7(react@18.2.0)
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
@@ -927,6 +927,9 @@ packages:
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
+  '@types/canvas-confetti@1.6.4':
+    resolution: {integrity: sha512-fNyZ/Fdw/Y92X0vv7B+BD6ysHL4xVU5dJcgzgxLdGbn8O3PezZNIJpml44lKM0nsGur+o/6+NZbZeNTt00U1uA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -1161,6 +1164,9 @@ packages:
 
   caniuse-lite@1.0.30001583:
     resolution: {integrity: sha512-acWTYaha8xfhA/Du/z4sNZjHUWjkiuoAi2LM+T/aL+kemKQgPT1xBb/YKjlQ0Qo8gvbHsGNplrEJ+9G3gL7i4Q==}
+
+  canvas-confetti@1.9.3:
+    resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2174,6 +2180,11 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  react-canvas-confetti@2.0.7:
+    resolution: {integrity: sha512-DIj44O35TPAwJkUSIZqWdVsgAMHtVf8h7YNmnr3jF3bn5mG+d7Rh9gEcRmdJfYgRzh6K+MAGujwUoIqQyLnMJw==}
+    peerDependencies:
+      react: '*'
 
   react-dom@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -3906,6 +3917,8 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.6.2
 
+  '@types/canvas-confetti@1.6.4': {}
+
   '@types/cookie@0.6.0': {}
 
   '@types/json5@0.0.29': {}
@@ -4196,6 +4209,8 @@ snapshots:
 
   caniuse-lite@1.0.30001583: {}
 
+  canvas-confetti@1.9.3: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4444,8 +4459,8 @@ snapshots:
       '@typescript-eslint/parser': 6.14.0(eslint@8.55.0)(typescript@5.3.3)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.55.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.55.0)
       eslint-plugin-react: 7.33.2(eslint@8.55.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.55.0)
@@ -4463,13 +4478,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.55.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.55.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.55.0))(eslint@8.55.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -4480,18 +4495,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.55.0))(eslint@8.55.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.14.0(eslint@8.55.0)(typescript@5.3.3)
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.55.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -4501,7 +4516,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.55.0))(eslint@8.55.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.14.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.55.0))(eslint@8.55.0))(eslint@8.55.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -5351,6 +5366,12 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-canvas-confetti@2.0.7(react@18.2.0):
+    dependencies:
+      '@types/canvas-confetti': 1.6.4
+      canvas-confetti: 1.9.3
+      react: 18.2.0
 
   react-dom@18.2.0(react@18.2.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react:
         specifier: ^18
         version: 18.2.0
+      react-canvas-confetti: 
+        specifier: ^2.0.7
+        version: 2.0.7
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.2.0)


### PR DESCRIPTION
Adds confetti to passport generation (When a new passport image is generated) and on /activated (On page load). Now with too many formatting-based commits!

Notes:
 - Adds dependency on [react-canvas-confetti](https://www.npmjs.com/package/react-canvas-confetti)
 - Confetti design(?) is open to comments and changes
   - Confetti can be configured in lib/confetti.tsx
   
 Closes #14 