### PR TITLE
Move Launch Confetti to playground.tsx

### DIFF
--- a/components/image-actions.tsx
+++ b/components/image-actions.tsx
@@ -3,7 +3,6 @@
 import { Passport } from "@/types/types";
 import { Button } from "./ui/button";
 import { useEffect, useState } from "react";
-import LaunchConfetti from "@/lib/confetti";
 
 export function ImageActions({
   generatedImageUrl,
@@ -48,7 +47,6 @@ export function ImageActions({
         <Button className="w-full amberButton" type="button">
           Download
         </Button>
-        <LaunchConfetti />
       </a>
       {userId && (latestPassport || sendToDb) ? (
         <div>

--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -114,6 +114,7 @@ export default function Playground({
     generatedImageUrl === "/passport/default.png" ? true : false
   );
   const [isLoading, setIsLoading] = useState(false); // TODO: do this better
+  const [launchConfetti, setLaunchConfetti] = useState(false); // TODO: do this better
   const [croppedImageFile, setCroppedImageFile] = useState<File>();
   const [generationSteps, setGenerationSteps] = useState<GenerationStep[]>(
     GENERATION_STEPS.base
@@ -140,6 +141,7 @@ export default function Playground({
 
   async function onSubmit(data: z.infer<typeof FormSchema>) {
     setIsLoading(true);
+    setLaunchConfetti(false);
 
     let generatedPassportNumber = data.passportNumber || "0";
 
@@ -202,6 +204,7 @@ export default function Playground({
     setIsLoading(false);
     setIsDefaultImage(false);
     resetGenerationSteps();
+    setLaunchConfetti(true);
   }
 
   return (
@@ -398,9 +401,6 @@ export default function Playground({
                   {step.status === "completed" ? (
                     <CheckCircle color="var(--success)" width={16} />
                   ) : null}
-                  {step.status === "completed" ? (
-                    <LaunchConfetti /> 
-                  ) : null}
                 </div>
               ))}
             </ul>
@@ -414,6 +414,9 @@ export default function Playground({
               surname={form.getValues().surname}
               sendToDb={form.getValues().sendToDb}
             />
+          ) : null}
+          {launchConfetti ? (
+            <LaunchConfetti /> 
           ) : null}
         </div>
       </aside>

--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -2,6 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
+import LaunchConfetti from "@/lib/confetti";
+
 import * as z from "zod";
 
 import { Button } from "@/components/ui/button";
@@ -410,6 +412,7 @@ export default function Playground({
               sendToDb={form.getValues().sendToDb}
             />
           ) : null}
+          {!isDefaultImage && !isLoading ? <LaunchConfetti /> : null}
         </div>
       </aside>
     </main>

--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -398,6 +398,9 @@ export default function Playground({
                   {step.status === "completed" ? (
                     <CheckCircle color="var(--success)" width={16} />
                   ) : null}
+                  {step.status === "completed" ? (
+                    <LaunchConfetti /> 
+                  ) : null}
                 </div>
               ))}
             </ul>
@@ -412,7 +415,6 @@ export default function Playground({
               sendToDb={form.getValues().sendToDb}
             />
           ) : null}
-          {!isDefaultImage && !isLoading ? <LaunchConfetti /> : null}
         </div>
       </aside>
     </main>


### PR DESCRIPTION
I discovered an oversight that meant confetti was launching on /activated, and on the passport generation page if you had a pre-existing passport. This fixes that. 

... whoops.