### PR TITLE
Handle R2 upload errors

### DIFF
--- a/app/api/generate-full-frame/route.ts
+++ b/app/api/generate-full-frame/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request) {
 			portrait: portraitImage,
 			sendToDb: sendToDb === "true",
 		},
-		request.url,
+		request.url
 	);
 	const fullFrameBlob = await fullFrameRes.blob();
 	const fullFrameFile = new File([fullFrameBlob], "data_page.png", {
@@ -39,7 +39,19 @@ export async function POST(request: Request) {
 	const data = new FormData();
 	data.append("fullFrameImage", fullFrameFile);
 
-	await uploadImageToR2("full", data, String(trueID));
+	try {
+		await uploadImageToR2("full", data, String(trueID));
+	} catch (error) {
+		return Response.json(
+			{
+				ok: false,
+				error: `Error uploading full image to R2: ${error}`,
+			},
+			{
+				status: 500,
+			}
+		);
+	}
 
 	return Response.json({ ok: true });
 }

--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -183,14 +183,35 @@ export default function Playground({
 		updateGenerationStepState("generating_data_page", "completed");
 
 		if (data.sendToDb) {
-			await fetch(`/api/generate-full-frame`, {
+			const generateFullFrameReq = await fetch(`/api/generate-full-frame`, {
 				method: "POST",
 				body: apiFormData,
 			});
+			if (generateFullFrameReq.status !== 200) {
+				alert(
+					"Wtf for some reason your full data page failed to upload. Try again? If this issue persists DM Matthew"
+				);
+				setIsLoading(false);
+				resetGenerationSteps();
+				return;
+			}
 			updateGenerationStepState("generating_frame", "completed");
 
 			apiFormData.append("generatedImage", generatedImageFile);
-			await uploadImageToR2("generated", apiFormData, generatedPassportNumber);
+			try {
+				await uploadImageToR2(
+					"generated",
+					apiFormData,
+					generatedPassportNumber
+				);
+			} catch (error) {
+				alert(
+					"Wtf for some reason your data page failed to upload. Try again? If this issue persists DM Matthew"
+				);
+				setIsLoading(false);
+				resetGenerationSteps();
+				return;
+			}
 
 			updateGenerationStepState("uploading", "completed");
 		}


### PR DESCRIPTION
First step for #47 

A future PR will display this error in a toast or modal instead of JavaScript alert, but want to get error handling out first since people are running into this.

Another future PR will prevent the website from crashing if the image doesn't load.