### PR TITLE
Bump passport limit

### DIFF
--- a/components/playground.tsx
+++ b/components/playground.tsx
@@ -107,7 +107,7 @@ export default function Playground({
 	// limit this week's signups.
 	// https://github.com/purduehackers/passport-issuing-office/pull/36
 	const registerCheckboxDisabled =
-		latestOverallPassportId === 80 &&
+		latestOverallPassportId === 81 &&
 		(!latestPassport || latestPassport.activated);
 
 	const [generatedImageUrl, setGeneratedImageUrl] = useState<string>(


### PR DESCRIPTION
Bump `latestOverallPassportId === 80` to 81 to allow for one passport to be made on 09/23/2024.