### PR TITLE
Fix ceremony timezone being stuck in UTC

### DIFF
--- a/components/admin.tsx
+++ b/components/admin.tsx
@@ -36,7 +36,11 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { Ceremony, Passport } from "@/types/types";
-import { getAllPassports, getCeremonyList, getFullCeremonyList } from "@/lib/get-passport-data";
+import {
+	getAllPassports,
+	getCeremonyList,
+	getFullCeremonyList,
+} from "@/lib/get-passport-data";
 import { useEffect, useState } from "react";
 import {
 	getCeremonyTimeDate,
@@ -45,7 +49,9 @@ import {
 	getCeremonyTimeStringFullDate,
 	getCeremonyTimeStringTime,
 } from "@/lib/ceremony-data";
-import CeremonyDropdown, { FullCeremonyDropdown } from "@/lib/ceremony-dropdown"
+import CeremonyDropdown, {
+	FullCeremonyDropdown,
+} from "@/lib/ceremony-dropdown";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import {
 	Form,
@@ -142,9 +148,8 @@ export const passportColumns: ColumnDef<Passport>[] = [
 		header: "Ceremony Time",
 		cell: ({ row }) => (
 			<div className="capitalize">
-				{getCeremonyTimeStringFullDate(row.getValue("ceremony_time"))}{" "}
-				-
-				{" "}{getCeremonyTimeStringTime(row.getValue("ceremony_time"))}
+				{getCeremonyTimeStringFullDate(row.getValue("ceremony_time"))} -{" "}
+				{getCeremonyTimeStringTime(row.getValue("ceremony_time"))}
 			</div>
 		),
 	},
@@ -162,13 +167,12 @@ export const ceremonyColumns: ColumnDef<Ceremony>[] = [
 					Ceremony Time
 					<ArrowUpDown className="ml-2 h-4 w-4" />
 				</Button>
-			)
+			);
 		},
 		cell: ({ row }) => (
 			<div className="capitalize">
-				{getCeremonyTimeStringFullDate(row.getValue("ceremony_time"))}{" "}
-				-
-				{" "}{getCeremonyTimeStringTime(row.getValue("ceremony_time"))}
+				{getCeremonyTimeStringFullDate(row.getValue("ceremony_time"))} -{" "}
+				{getCeremonyTimeStringTime(row.getValue("ceremony_time"))}
 			</div>
 		),
 		enableSorting: true,
@@ -378,13 +382,13 @@ export default function AdminPage() {
 			try {
 				const result = await getAllPassports();
 				setPassportData(result ?? []);
-			} catch (e) { }
+			} catch (e) {}
 		};
 		const fetchCeremonyData = async () => {
 			try {
 				const result = await getFullCeremonyList();
 				setCeremonyData(result ?? []);
-			} catch (e) { }
+			} catch (e) {}
 		};
 
 		if (reloadDatabase) {
@@ -402,10 +406,11 @@ export default function AdminPage() {
 	const [passportColumnVisibility, setPassportColumnVisibility] =
 		React.useState<VisibilityState>({});
 	const [passportRowSelection, setPassportRowSelection] = React.useState({});
-	const [passportPagination, setPassportPagination] = React.useState<PaginationState>({
-		pageIndex: 0,
-		pageSize: 5,
-	})
+	const [passportPagination, setPassportPagination] =
+		React.useState<PaginationState>({
+			pageIndex: 0,
+			pageSize: 5,
+		});
 
 	const [ceremonySorting, setCeremonySorting] = React.useState<SortingState>(
 		[],
@@ -415,10 +420,11 @@ export default function AdminPage() {
 	const [ceremonyColumnVisibility, setCeremonyColumnVisibility] =
 		React.useState<VisibilityState>({});
 	const [ceremonyRowSelection, setCeremonyRowSelection] = React.useState({});
-	const [ceremonyPagination, setCeremonyPagination] = React.useState<PaginationState>({
-		pageIndex: 0,
-		pageSize: 5,
-	})
+	const [ceremonyPagination, setCeremonyPagination] =
+		React.useState<PaginationState>({
+			pageIndex: 0,
+			pageSize: 5,
+		});
 
 	const passportTable = useReactTable({
 		data: passportData,
@@ -495,7 +501,7 @@ export default function AdminPage() {
 													.getColumn("ceremony_time")
 													?.getFilterValue() ?? "") as string,
 											).toLocaleDateString("en-US", {
-												timeZone: "UTC",
+												timeZone: "America/Indianapolis",
 												day: "numeric",
 												month: "long",
 												year: "numeric",
@@ -506,7 +512,7 @@ export default function AdminPage() {
 													.getColumn("ceremony_time")
 													?.getFilterValue() ?? "") as string,
 											).toLocaleTimeString("en-US", {
-												timeZone: "UTC",
+												timeZone: "America/Indianapolis",
 												hour: "numeric",
 												minute: "numeric",
 												hour12: true,
@@ -530,7 +536,9 @@ export default function AdminPage() {
 											column?.setFilterValue("");
 											setCeremonyTime("noPassportCeremony");
 										} else {
-											column?.setFilterValue(getCeremonyTimeDate(e).toISOString());
+											column?.setFilterValue(
+												getCeremonyTimeDate(e).toISOString(),
+											);
 											setCeremonyTime(e);
 										}
 									}}
@@ -586,9 +594,9 @@ export default function AdminPage() {
 													{header.isPlaceholder
 														? null
 														: flexRender(
-															header.column.columnDef.header,
-															header.getContext(),
-														)}
+																header.column.columnDef.header,
+																header.getContext(),
+															)}
 												</TableHead>
 											);
 										})}
@@ -598,9 +606,7 @@ export default function AdminPage() {
 							<TableBody>
 								{passportTable.getRowModel().rows?.length ? (
 									passportTable.getRowModel().rows.map((row) => (
-										<TableRow
-											key={row.id}
-										>
+										<TableRow key={row.id}>
 											{row.getVisibleCells().map((cell) => (
 												<TableCell key={cell.id}>
 													{flexRender(
@@ -661,9 +667,9 @@ export default function AdminPage() {
 													{header.isPlaceholder
 														? null
 														: flexRender(
-															header.column.columnDef.header,
-															header.getContext(),
-														)}
+																header.column.columnDef.header,
+																header.getContext(),
+															)}
 												</TableHead>
 											);
 										})}
@@ -673,9 +679,7 @@ export default function AdminPage() {
 							<TableBody>
 								{ceremonyTable.getRowModel().rows?.length ? (
 									ceremonyTable.getRowModel().rows.map((row) => (
-										<TableRow
-											key={row.id}
-										>
+										<TableRow key={row.id}>
 											{row.getVisibleCells().map((cell) => (
 												<TableCell key={cell.id}>
 													{flexRender(
@@ -792,7 +796,9 @@ export default function AdminPage() {
 															<Input
 																type="time"
 																value={timeValue}
-																onChange={(e) => { field.onChange(handleTimeChange(e)) }}
+																onChange={(e) => {
+																	field.onChange(handleTimeChange(e));
+																}}
 																className={cn(
 																	"pl-3 pr-3 text-left font-normal",
 																	!field.value && "text-muted-foreground",
@@ -882,7 +888,7 @@ export default function AdminPage() {
 																			className="w-full"
 																		>
 																			{modifyCeremonyTime ==
-																				"noPassportCeremony" ? (
+																			"noPassportCeremony" ? (
 																				<p>Select a Date</p>
 																			) : (
 																				<p>
@@ -1006,7 +1012,7 @@ export default function AdminPage() {
 																			className="w-full"
 																		>
 																			{deleteCeremonyTime ==
-																				"noPassportCeremony" ? (
+																			"noPassportCeremony" ? (
 																				<p>Select a Date</p>
 																			) : (
 																				<p>

--- a/lib/ceremony-data.tsx
+++ b/lib/ceremony-data.tsx
@@ -41,13 +41,13 @@ export function getCeremonyTimeString(
 	return (
 		<span>
 			{ceremonyDate.toLocaleDateString("en-US", {
-				timeZone: "UTC",
+				timeZone: "America/Indianapolis",
 				day: "numeric",
 				month: "numeric",
 			})}{" "}
 			-{" "}
 			{ceremonyDate.toLocaleTimeString("en-US", {
-				timeZone: "UTC",
+				timeZone: "America/Indianapolis",
 				hour: "numeric",
 				minute: "numeric",
 				hour12: true,
@@ -71,7 +71,7 @@ export function getCeremonyTimeStringDate(ceremony: string | Date) {
 	return (
 		<span>
 			{ceremonyDate.toLocaleDateString("en-US", {
-				timeZone: "UTC",
+				timeZone: "America/Indianapolis",
 				day: "numeric",
 				month: "numeric",
 			})}{" "}
@@ -94,7 +94,7 @@ export function getCeremonyTimeStringFullDate(ceremony: string | Date) {
 	return (
 		<span>
 			{ceremonyDate.toLocaleDateString("en-US", {
-				timeZone: "UTC",
+				timeZone: "America/Indianapolis",
 				day: "numeric",
 				month: "long",
 				year: "numeric",
@@ -119,7 +119,7 @@ export function getCeremonyTimeStringTime(ceremony: string | Date) {
 		<span>
 			{" "}
 			{ceremonyDate.toLocaleTimeString("en-US", {
-				timeZone: "UTC",
+				timeZone: "America/Indianapolis",
 				hour: "numeric",
 				minute: "numeric",
 				hour12: true,

--- a/lib/ceremony-dropdown.tsx
+++ b/lib/ceremony-dropdown.tsx
@@ -49,13 +49,13 @@ export default function CeremonyDropdown({
 							disabled={!ceremony.open_registration}
 						>
 							{new Date(ceremony.ceremony_time).toLocaleDateString("en-US", {
-								timeZone: "UTC",
+								timeZone: "America/Indianapolis",
 								day: "numeric",
 								month: "numeric",
 							})}{" "}
 							-{" "}
 							{new Date(ceremony.ceremony_time).toLocaleTimeString("en-US", {
-								timeZone: "UTC",
+								timeZone: "America/Indianapolis",
 								hour: "numeric",
 								minute: "numeric",
 								hour12: true,

--- a/lib/ceremony-dropdown.tsx
+++ b/lib/ceremony-dropdown.tsx
@@ -133,13 +133,13 @@ export function FullCeremonyDropdown() {
 							className="flex justify-between items-center"
 						>
 							{new Date(ceremony.ceremony_time).toLocaleDateString("en-US", {
-								timeZone: "UTC",
+								timeZone: "America/Indianapolis",
 								day: "numeric",
 								month: "numeric",
 							})}{" "}
 							-{" "}
 							{new Date(ceremony.ceremony_time).toLocaleTimeString("en-US", {
-								timeZone: "UTC",
+								timeZone: "America/Indianapolis",
 								hour: "numeric",
 								minute: "numeric",
 								hour12: true,

--- a/lib/ceremony-utils.ts
+++ b/lib/ceremony-utils.ts
@@ -4,17 +4,28 @@ import prisma from "@/lib/prisma";
 import { Ceremony } from "@/types/types";
 
 export async function addNewCeremony(ceremonyData: Ceremony) {
+	console.log({
+		time: new Date(ceremonyData.ceremony_time.getTime()),
+		timezoneOffset: ceremonyData.ceremony_time.getTimezoneOffset() * 60000,
+		calculation: new Date(
+			ceremonyData.ceremony_time.getTime() -
+				ceremonyData.ceremony_time.getTimezoneOffset() * 60000,
+		),
+	});
 	try {
 		await prisma.ceremonies.create({
 			data: {
-				ceremony_time: (new Date(ceremonyData.ceremony_time.getTime() - (ceremonyData.ceremony_time.getTimezoneOffset() * 60000))),
+				ceremony_time: new Date(
+					ceremonyData.ceremony_time.getTime() -
+						ceremonyData.ceremony_time.getTimezoneOffset() * 60000,
+				),
 				total_slots: ceremonyData.total_slots,
 				open_registration: ceremonyData.open_registration,
 			},
 		});
 		return true;
 	} catch (_err) {
-		console.log(_err)
+		console.log(_err);
 		return false;
 	}
 }

--- a/lib/ceremony-utils.ts
+++ b/lib/ceremony-utils.ts
@@ -4,21 +4,10 @@ import prisma from "@/lib/prisma";
 import { Ceremony } from "@/types/types";
 
 export async function addNewCeremony(ceremonyData: Ceremony) {
-	console.log({
-		time: new Date(ceremonyData.ceremony_time.getTime()),
-		timezoneOffset: ceremonyData.ceremony_time.getTimezoneOffset() * 60000,
-		calculation: new Date(
-			ceremonyData.ceremony_time.getTime() -
-				ceremonyData.ceremony_time.getTimezoneOffset() * 60000,
-		),
-	});
 	try {
 		await prisma.ceremonies.create({
 			data: {
-				ceremony_time: new Date(
-					ceremonyData.ceremony_time.getTime() -
-						ceremonyData.ceremony_time.getTimezoneOffset() * 60000,
-				),
+				ceremony_time: new Date(ceremonyData.ceremony_time.getTime()),
 				total_slots: ceremonyData.total_slots,
 				open_registration: ceremonyData.open_registration,
 			},


### PR DESCRIPTION
Ignore the diff, my code editor ran format on save. The actual diff is that I replaced all instances of `timeZone: "UTC"` with `timeZone: "America/Indianapolis"`. We probably do want the dates to be saved in the database as UTC, but just rendered on the client in eastern time. We don't want them to be rendered in the client's timezone because we know that passport ceremonies will always run in eastern time.

This change also makes the `timezoneOffset` stuff no longer necessary, so I removed that too.